### PR TITLE
Fixed authentication for at least Django 1.4.2

### DIFF
--- a/jsonrpc/__init__.py
+++ b/jsonrpc/__init__.py
@@ -195,7 +195,8 @@ def jsonrpc_method(name, authenticated=False,
             creds = args[:len(authentication_arguments)]
             if len(creds) == 0:
                 raise IndexError
-            user = _authenticate(*creds)
+            # Django's authenticate() method takes arguments as dict
+            user = _authenticate(username=creds[0], password=creds[1], *creds[2:])
             if user is not None:
               args = args[len(authentication_arguments):]
           except IndexError: 


### PR DESCRIPTION
A few commits ago the authentication against Django broke (tested against Django 1.4.2).
The jsonrpc/**init**.py imports the django contrib authenticate() method as _authenticate() which takes a dict only as parameters, but since "*creds" is a positional argument list, this wont work anymore. This fixes the problem.
