### PR TITLE
allow certain errors to be handled by jsonrpc, without sending django error signal

### DIFF
--- a/jsonrpc/site.py
+++ b/jsonrpc/site.py
@@ -176,14 +176,16 @@ class JSONRPCSite(object):
       status = 200
     
     except Error, e:
-      signals.got_request_exception.send(sender=self.__class__, request=request)
+      if not e.__class__.__name__ in HANDLED_ERRORS:
+        signals.got_request_exception.send(sender=self.__class__, request=request)
       response['error'] = e.json_rpc_format
       if version in ('1.1', '2.0') and 'result' in response:
         response.pop('result')
       status = e.status
     except Exception, e:
       # exception missed by others
-      signals.got_request_exception.send(sender=self.__class__, request=request)
+      if not e.__class__.__name__ in HANDLED_ERRORS:
+        signals.got_request_exception.send(sender=self.__class__, request=request)
       other_error = OtherError(e)
       response['error'] = other_error.json_rpc_format
       status = other_error.status


### PR DESCRIPTION
Jsonrpc can spam logs, so i needed a way to ignore certain types of errors
from being routed to error handlers.
This patch will create django setting which allows to specify list of exception class names.
Any exception from this list will not generate error signal.
