### PR TITLE
Django 1.7 requires lazy ugettxt for not accessing app registry on import time

### DIFF
--- a/jsonrpc/exceptions.py
+++ b/jsonrpc/exceptions.py
@@ -1,5 +1,5 @@
 try:
-  from django.utils.translation import gettext as _
+  from django.utils.translation import gettext_lazy as _
   _("You're lazy...") # this function lazy-loads settings
 except (ImportError, NameError):
   _ = lambda t, *a, **k: t


### PR DESCRIPTION
1.7a compliance fixes according to https://docs.djangoproject.com/en/dev/releases/1.7/#start-up-sequence