### PR TITLE
Created Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,68 @@
+language: python
+# List of Python and Django version combinations to test
+matrix:
+  fast_finish: true
+  include:
+    - python: 2.6
+      env: DJANGO_VERSION=1.4.*
+    - python: 2.6
+      env: DJANGO_VERSION=1.5.*
+    - python: 2.6
+      env: DJANGO_VERSION=1.6.*
+    - python: 2.7
+      env: DJANGO_VERSION=1.4.*
+    - python: 2.7
+      env: DJANGO_VERSION=1.5.*
+    - python: 2.7
+      env: DJANGO_VERSION=1.6.*
+    - python: 2.7
+      env: DJANGO_VERSION=1.7.*
+    - python: 2.7
+      env: DJANGO_VERSION=1.8.*
+    - python: 3.2
+      env: DJANGO_VERSION=1.5.*
+    - python: 3.2
+      env: DJANGO_VERSION=1.6.*
+    - python: 3.2
+      env: DJANGO_VERSION=1.7.*
+    - python: 3.2
+      env: DJANGO_VERSION=1.8.*
+    - python: 3.3
+      env: DJANGO_VERSION=1.5.*
+    - python: 3.3
+      env: DJANGO_VERSION=1.6.*
+    - python: 3.3
+      env: DJANGO_VERSION=1.7.*
+    - python: 3.3
+      env: DJANGO_VERSION=1.8.*
+    - python: 3.4
+      env: DJANGO_VERSION=1.7.*
+    - python: 3.4
+      env: DJANGO_VERSION=1.8.*
+# Python 3 are allowed to fail because it is not supported at this moment
+  allow_failures:
+    - python: 3.2
+      env: DJANGO_VERSION=1.5.*
+    - python: 3.2
+      env: DJANGO_VERSION=1.6.*
+    - python: 3.2
+      env: DJANGO_VERSION=1.7.*
+    - python: 3.2
+      env: DJANGO_VERSION=1.8.*
+    - python: 3.3
+      env: DJANGO_VERSION=1.5.*
+    - python: 3.3
+      env: DJANGO_VERSION=1.6.*
+    - python: 3.3
+      env: DJANGO_VERSION=1.7.*
+    - python: 3.3
+      env: DJANGO_VERSION=1.8.*
+    - python: 3.4
+      env: DJANGO_VERSION=1.7.*
+    - python: 3.4
+      env: DJANGO_VERSION=1.8.*
+# command to install Django
+install:
+  - pip install -q Django==$DJANGO_VERSION
+# command to run tests
+script: python test/test.py


### PR DESCRIPTION
I have created a configuration file for Travis CI (https://travis-ci.org/) to automatically run the tests with several combinations of Python and Django.

The tests are configured for Python versions 2.6, 2.7, 3.2, 3.3 and 3.4 and Django versions 1.4 - 1.8 in the combinations officially supported by Django. Tests for Python 3 are listed in allow_failures because this project is not yet Python 3 compatible.

If you would like to use it, you only need to enable Travis for this project on https://travis-ci.org/. Combined with this configuration file, tests will be automatically run for every push to the repo and for every pull request.

Travis CI is free to use for open source software.