### PR TITLE
Fixed TypeError when a method with authenticated=True is called with insufficient arguments

### DIFF
--- a/jsonrpc/__init__.py
+++ b/jsonrpc/__init__.py
@@ -233,8 +233,8 @@ def jsonrpc_method(name,
                         except KeyError:
                             raise InvalidParamsError(
                                 'Authenticated methods require at least '
-                                '[%s] or {%s} arguments',
-                                authentication_arguments)
+                                '[%(arguments)s] or {%(arguments)s} arguments' %
+                                {'arguments': ', '.join(authentication_arguments)})
 
                         user = _authenticate(**auth_kwargs)
                         if user is not None:

--- a/test/test.py
+++ b/test/test.py
@@ -428,6 +428,27 @@ class JSONRPCTest(JSONServerTestCase):
     else:
       self.assert_(False, 'Didnt return status code 401 on unauthorized access')
 
+  def test_authenticated_insufficient_kwargs(self):
+    """
+    Test method with required authentication with insufficient keyword arguments.
+    """
+
+    resp = self.proxy20.jsonrpc.testAuth(string='this is a string')
+
+    # Expected: InvalidParamsError (code -32602)
+    self.assert_('result' not in resp)
+    self.assertEquals(resp['error']['code'], -32602)
+
+  def test_authenticated_insufficient_args(self):
+    """
+    Test method with required authentication with insufficient arguments.
+    """
+    resp = self.proxy10.jsonrpc.testAuth('this is a string')
+
+    # Expected: InvalidParamsError (code -32602)
+    self.assertEquals(resp['result'], None)
+    self.assertEquals(resp['error']['code'], -32602)
+
 
 if __name__ == '__main__':
   server = None


### PR DESCRIPTION
When a method with authenticated=True is called with insufficient arguments a TypeError is raised resulting in an Internal server error.

This commit fixes the creation of the InvalidParamsError which should be raised and also creates two test cases.

This commit fixes samuraisam/django-json-rpc#54