### PR TITLE
Do not call signals.got_request_exception for expected exceptions.

### DIFF
--- a/jsonrpc/site.py
+++ b/jsonrpc/site.py
@@ -201,8 +201,6 @@ class JSONRPCSite(object):
             status = 200
 
         except Error as e:
-            signals.got_request_exception.send(sender=self.__class__,
-                                               request=request)
             response['error'] = e.json_rpc_format
             if version in ('1.1', '2.0') and 'result' in response:
                 response.pop('result')
@@ -265,8 +263,6 @@ class JSONRPCSite(object):
 
             json_rpc = dumps(response, cls=json_encoder)
         except Error as e:
-            signals.got_request_exception.send(sender=self.__class__,
-                                               request=request)
             response['error'] = e.json_rpc_format
             status = e.status
             json_rpc = dumps(response, cls=json_encoder)


### PR DESCRIPTION
Subclasses of jsonrpc.exceptions.Error are used to return JSONRPC error responses in well defined situations and should not call the got_request_exception signal used for uncaught exceptions.

This is similar to the behaviour of the Django Http404 exception.

This pull request is similar to samuraisam/django-json-rpc#40 but without using a configuration option.