### PR TITLE
Put stacktrace into the OtherError only if DEBUG is enabled

### DIFF
--- a/jsonrpc/site.py
+++ b/jsonrpc/site.py
@@ -4,6 +4,7 @@ from uuid import uuid1
 from jsonrpc._json import loads, dumps
 from jsonrpc.exceptions import *
 from jsonrpc._types import *
+from django.conf import settings
 from django.core import signals
 from django.utils.encoding import smart_text
 empty_dec = lambda f: f
@@ -211,7 +212,13 @@ class JSONRPCSite(object):
             # exception missed by others
             signals.got_request_exception.send(sender=self.__class__,
                                                request=request)
-            other_error = OtherError(e)
+
+            # Put stacktrace into the OtherError only if DEBUG is enabled
+            if settings.DEBUG:
+                other_error = OtherError(e)
+            else:
+                other_error = OtherError("Internal Server Error")
+
             response['error'] = other_error.json_rpc_format
             status = other_error.status
             if version in ('1.1', '2.0') and 'result' in response:
@@ -274,7 +281,13 @@ class JSONRPCSite(object):
             # exception missed by others
             signals.got_request_exception.send(sender=self.__class__,
                                                request=request)
-            other_error = OtherError(e)
+
+            # Put stacktrace into the OtherError only if DEBUG is enabled
+            if settings.DEBUG:
+                other_error = OtherError(e)
+            else:
+                other_error = OtherError("Internal Server Error")
+
             response['result'] = None
             response['error'] = other_error.json_rpc_format
             status = other_error.status


### PR DESCRIPTION
It is good practise to not produce detailed error messages in production environments, when DEBUG is off.

This pull request will only put the stacktrace into the OtherError if DEBUG is enabled.

See also the [Django documentation on the DEBUG setting](https://docs.djangoproject.com/en/1.8/ref/settings/#debug).