### PR TITLE
Fix for tuple return, use any instead of sum

### DIFF
--- a/jsonrpc/site.py
+++ b/jsonrpc/site.py
@@ -215,10 +215,13 @@ class JSONRPCSite(object):
             if 'id' not in D or ('id' in D and D['id'] is None):  # notification
                 return None, 204
 
+            if isinstance(R, tuple):
+                R = list(R)
+
             encoder = json_encoder()
             builtin_types = (dict, list, set, NoneType, bool, six.text_type
                        ) + six.integer_types + six.string_types
-            if not sum([isinstance(R, e) for e in builtin_types]):
+            if all(not isinstance(R, e) for e in builtin_types):
                 try:
                     rs = encoder.default(R)  # ...or something this thing supports
                 except TypeError as exc:

--- a/test/test.py
+++ b/test/test.py
@@ -186,6 +186,10 @@ def authCheckedEcho(request, obj1, arr1):
 def checkedVarArgsEcho(request, *args, **kw):
   return list(args) + list(kw.values())
 
+@jsonrpc_method('jsonrpc.tuple() -> Array', validate=True)
+def returnTuple(request):
+    return 1, 0
+
 
 class JSONRPCFunctionalTests(unittest.TestCase):
   def test_method_parser(self):
@@ -448,6 +452,16 @@ class JSONRPCTest(JSONServerTestCase):
     # Expected: InvalidParamsError (code -32602)
     self.assertEquals(resp['result'], None)
     self.assertEquals(resp['error']['code'], -32602)
+
+  def test_return_tuple_10(self):
+    resp = self.proxy10.jsonrpc.tuple()
+
+    self.assertEqual(resp['result'], [1, 0])
+
+  def test_return_tuple_20(self):
+    resp = self.proxy20.jsonrpc.tuple()
+
+    self.assertEqual(resp['result'], [1, 0])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tests added for tuple return

Either way this was wrong when `tuple` was returned from within the rpc function: the `TypeError` had a `tuple` for `%r` formatting which was wrong and resulted in uncomprehensible error:

https://github.com/samuraisam/django-json-rpc/blob/master/jsonrpc/site.py#L225

The behavior of converting `tuple` to `list` is consistent with what `json-rpc` does (https://pypi.python.org/pypi/json-rpc/).